### PR TITLE
Handle git push permission error

### DIFF
--- a/.github/workflows/update-all-years.yml
+++ b/.github/workflows/update-all-years.yml
@@ -7,6 +7,9 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update-all-years:
     runs-on: ubuntu-latest
@@ -15,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_PUSH_TOKEN }}
       
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -33,6 +36,7 @@ jobs:
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
+          token: ${{ secrets.REPO_PUSH_TOKEN }}
           commit_message: 'Data: Quarterly full update for all years'
           file_pattern: 'data/*'
           commit_user_name: 'Anime Tracker Bot'

--- a/.github/workflows/update-current-years.yml
+++ b/.github/workflows/update-current-years.yml
@@ -7,6 +7,9 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update-current-years:
     runs-on: ubuntu-latest
@@ -15,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_PUSH_TOKEN }}
       
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -33,6 +36,7 @@ jobs:
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
+          token: ${{ secrets.REPO_PUSH_TOKEN }}
           commit_message: 'Data: Weekly update for current years'
           file_pattern: 'data/*'
           commit_user_name: 'Anime Tracker Bot'


### PR DESCRIPTION
Update GitHub Actions workflows to resolve 403 permission errors when pushing changes.

The `github-actions[bot]` was encountering 403 errors when attempting to push changes due to insufficient permissions. This PR explicitly grants `contents: write` permissions to the workflows and configures both the checkout and auto-commit steps to use a dedicated `REPO_PUSH_TOKEN` secret for write operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f83628d-cdca-4d8a-b07b-5b1ef9274f6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6f83628d-cdca-4d8a-b07b-5b1ef9274f6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

