### PR TITLE
Handle missing authentication token

### DIFF
--- a/.github/workflows/update-all-years.yml
+++ b/.github/workflows/update-all-years.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.REPO_PUSH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -36,7 +36,6 @@ jobs:
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          token: ${{ secrets.REPO_PUSH_TOKEN }}
           commit_message: 'Data: Quarterly full update for all years'
           file_pattern: 'data/*'
           commit_user_name: 'Anime Tracker Bot'

--- a/.github/workflows/update-current-years.yml
+++ b/.github/workflows/update-current-years.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.REPO_PUSH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -36,7 +36,6 @@ jobs:
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          token: ${{ secrets.REPO_PUSH_TOKEN }}
           commit_message: 'Data: Weekly update for current years'
           file_pattern: 'data/*'
           commit_user_name: 'Anime Tracker Bot'


### PR DESCRIPTION
Fix "Input required and not supplied: token" errors in GitHub Actions workflows.

The workflows were failing because `secrets.REPO_PUSH_TOKEN` was not configured. This PR updates the checkout action to use the automatically available `secrets.GITHUB_TOKEN` and removes redundant token parameters from the `git-auto-commit-action`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6a73108-88a0-4ebc-8b4e-8f0f0c44359c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6a73108-88a0-4ebc-8b4e-8f0f0c44359c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

